### PR TITLE
Feature/#17820 add intrusion pipeline

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -826,7 +826,7 @@ action :add do
         mode '0644'
         ignore_failure true
         cookbook 'logstash'
-        notifies :restart, 'service[logstash]', :delayed 
+        notifies :restart, 'service[logstash]', :delayed
       end
 
       template "#{pipelines_dir}/intrusion/02_geoenrich.conf" do

--- a/resources/templates/default/intrusion_darklist.conf.erb
+++ b/resources/templates/default/intrusion_darklist.conf.erb
@@ -1,0 +1,3 @@
+filter {
+    darklist {  }
+}

--- a/resources/templates/default/intrusion_encode.conf.erb
+++ b/resources/templates/default/intrusion_encode.conf.erb
@@ -1,0 +1,12 @@
+filter {
+  if [file_uri] {
+    ruby {
+      code => '
+        def rb_easy_unescape(str, encoding = Encoding::UTF_8)
+          str.dup.force_encoding("ASCII-8BIT").gsub(/%((?:\p{XDigit}{2})+)/n) { [$1].pack("H*") }.force_encoding(encoding)
+        end
+        event.set("file_uri", rb_easy_unescape(event.get("file_uri")))
+      '
+    }
+  }
+}

--- a/resources/templates/default/intrusion_geoenrich.conf.erb
+++ b/resources/templates/default/intrusion_geoenrich.conf.erb
@@ -1,0 +1,115 @@
+filter {
+  if [lan_ip] {
+    cidr {
+      address => [ "%{lan_ip}" ]
+      network => [ "0.0.0.0/32", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fc00::/7", "127.0.0.0/8", "::1/128","169.254.0.0/16", "fe80::/10","224.0.0.0/4", "ff00::/8","255.255.255.255/32" ]
+      add_field => { "[src_locality]" => "private" }
+    }
+  }
+  if [wan_ip]{
+    cidr {
+      address => [ "%{wan_ip}" ]
+      network => [ "0.0.0.0/32", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fc00::/7", "127.0.0.0/8", "::1/128","169.254.0.0/16", "fe80::/10","224.0.0.0/4", "ff00::/8","255.255.255.255/32" ]
+      add_field => { "[dst_locality]" => "private" }
+    }
+  }
+
+  if [src_locality] != "private" {
+    geoip {
+      id => "geoip_city_lan"
+      source => "lan_ip"
+      default_database_type => "City"
+      target => "city_lan"
+      fields => [COUNTRY_CODE2]
+    }
+    geoip {
+      id => "geoip_asn_lan"
+      source => "lan_ip"
+      default_database_type => "ASN"
+      target => "asn_lan"
+      fields => [AUTONOMOUS_SYSTEM_ORGANIZATION]
+    }
+  }
+  
+  if [dst_locality] != "private" {
+    geoip {
+      id => "geoip_city_wan"
+      source => "wan_ip"
+      default_database_type => "City"
+      target => "city_wan"
+      fields => [COUNTRY_CODE2]
+    }
+    geoip {
+      id => "geoip_asn_wan"
+      source => "wan_ip"
+      default_database_type => "ASN"
+      target => "asn_wan"
+      fields => [AUTONOMOUS_SYSTEM_ORGANIZATION]
+    } 
+  }
+
+  if [lan_ip] {
+    if [city_lan][country_code2] {
+      mutate {
+        add_field => { "src_country_code" => "%{[city_lan][country_code2]}" }
+      }
+    }
+    if [asn_lan][as_org] {
+      mutate {
+        add_field => { "src_asn_name" => "%{[asn_lan][as_org]}" }
+      }
+    }
+    if [src_country_code] {
+      mutate {
+        replace  => {
+          "public_ip" => "%{wan_ip}"
+          "ip_country_code" => "%{src_country_code}"
+          "lan_ip_country_code" => "%{src_country_code}"
+        }
+      }
+    }
+    if [src_asn_name] {
+      mutate {
+        add_field => {
+          "lan_ip_as_name" => "%{src_asn_name}"
+          "ip_as_name" => "%{src_asn_name}"
+        }
+      }
+    }
+  }
+
+  if [wan_ip]{
+    if [city_wan][country_code2] {
+      mutate {
+        add_field => { "dst_country_code" => "%{[city_wan][country_code2]}" }
+      }
+    }
+    if [asn_wan][as_org]{
+      mutate {
+        add_field => {"dst_asn_name" => "%{[asn_wan][as_org]}"}
+      }
+    }
+    if [dst_country_code]{
+      mutate {
+        replace  => {
+          "public_ip" => "%{wan_ip}"
+          "ip_country_code" => "%{dst_country_code}"
+          "wan_ip_country_code" => "%{dst_country_code}"
+        }
+      }
+    }
+    if [dst_asn_name]{
+      mutate {
+        replace => {
+          "wan_ip_as_name" => "%{dst_asn_name}"
+          "ip_as_name" => "%{dst_asn_name}"
+        }
+      }
+    } 
+  }
+
+  mutate {
+    remove_field => ["@version","@timestamp", "asn_wan", "asn_lan", "city_wan", "city_lan", "src_country_code", "src_asn_name", "dst_country_code", "dst_asn_name", "src_locality", "dst_locality"]
+  }
+}
+

--- a/resources/templates/default/intrusion_intrusion.conf.erb
+++ b/resources/templates/default/intrusion_intrusion.conf.erb
@@ -1,0 +1,8 @@
+filter {
+  intrusion { 
+  }
+
+  mutate {
+    remove_field => ["@version","@timestamp"]
+  }
+}

--- a/resources/templates/default/intrusion_macvendor.conf.erb
+++ b/resources/templates/default/intrusion_macvendor.conf.erb
@@ -1,0 +1,5 @@
+filter {
+  macvendorsenrich {
+    path => "<%= @mac_vendors %>"
+  }
+}

--- a/resources/templates/default/pipelines.yml.erb
+++ b/resources/templates/default/pipelines.yml.erb
@@ -63,6 +63,11 @@
   path.config: "/etc/logstash/pipelines/monitor"
   pipeline.workers: 1
   <% end %>
+  <% if @pipelines.include?("intrusion-pipeline") %>
+- pipeline.id: intrusion-pipeline
+  path.config: "/etc/logstash/pipelines/intrusion"
+  pipeline.workers: 1
+  <% end %>
   <% end %>
   <% if @is_manager or @is_proxy %>
   <% if @pipelines.include?("bulkstats-pipeline") %>


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/17820)

## Description / Motivation

This update involves adding the intrusion pipeline to the Logstash Cookbook.

## Details

- Pipeline Addition: The intrusion pipeline has been integrated into the manager pipelines list and the `pipelines.yml.erb` file.
- Configuration Templates:
  - `00_input.conf` now utilizes the `input_kafka.conf.erb` template.
  - `99_output.conf` now utilizes the `output_kafka_namespace.conf.erb` template.
- Unchanged Files: The following configuration files remain the same as in the previous version:
  - 01_intrusion.conf
  - 02_geoenrich.conf
  - 04_darklist.conf
  - 98_encode.conf
- Updated File Path: The `03_macvendor.conf` file now references the new path `/etc/objects/mac_vendors` instead of the old path `/opt/rb/etc/objects/mac_vendors`.